### PR TITLE
feat: add excludeSelectors option for stripping noise before HTML→MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ export default defineConfig({
       titleSelector: "h1",
       contentSelector: "main",
       exclude: ["404", "404.html", "_astro"],
+      excludeSelectors: ["aside", "form", "[data-llms-ignore]"],
       verbose: false,
     }),
   ],
@@ -94,7 +95,8 @@ All configuration is defined in `astro.config.mjs` via `llms({...})`. The integr
 | `generateLlmsFullTxt`  | boolean | `true`        | Generate llms-full.txt         |
 | `titleSelector`        | string  | `"h1"`        | CSS selector for page title    |
 | `contentSelector`      | string  | `"main"`      | CSS selector for main content  |
-| `exclude`              | array   | see below     | Patterns to exclude            |
+| `exclude`              | array   | see below     | File path patterns to exclude  |
+| `excludeSelectors`     | array   | `[]`          | CSS selectors to strip from content before HTML → MD conversion (see below) |
 | `verbose`              | boolean | `false`       | Detailed output                |
 
 ### Default Excludes
@@ -102,6 +104,68 @@ All configuration is defined in `astro.config.mjs` via `llms({...})`. The integr
 ```json
 ["404", "404.html", "_astro", "**.xml", "**.txt", "node_modules"]
 ```
+
+### Excluding noise from generated markdown
+
+By default, the integration converts everything inside your
+`contentSelector` (e.g. `<main>`) into markdown. On real sites that
+often includes sidebars, sign-up forms, navigation rails — all noise
+when the audience is an LLM.
+
+`excludeSelectors` is a list of CSS selectors that get **removed from
+the parsed content before** the HTML → Markdown conversion runs:
+
+```js
+import llms from "astro-llms-md";
+
+llms({
+  excludeSelectors: ["aside", "form", "[data-llms-ignore]"],
+});
+```
+
+#### Always stripped (non-overridable)
+
+Three selectors are always applied regardless of config:
+
+| Selector              | Why                                              |
+| --------------------- | ------------------------------------------------ |
+| `script`              | JS — never useful in markdown                    |
+| `style`               | CSS — same                                       |
+| `[data-llms-ignore]`  | Opt-in attribute for ad-hoc markup-side exclusion |
+
+The `[data-llms-ignore]` attribute is the lightweight escape hatch
+when you don't want to touch your integration config:
+
+```astro
+<aside data-llms-ignore>
+  <!-- form, ads, sign-up box, whatever — won't appear in the .md output -->
+</aside>
+```
+
+#### Opt-in default noise list
+
+If you want the common "strip the obvious noise" preset, spread the
+exported `DEFAULT_NOISE_SELECTORS` constant:
+
+```js
+import llms, { DEFAULT_NOISE_SELECTORS } from "astro-llms-md";
+
+llms({
+  excludeSelectors: [
+    ...DEFAULT_NOISE_SELECTORS,
+    ".my-custom-noise-class",
+  ],
+});
+```
+
+`DEFAULT_NOISE_SELECTORS` resolves to:
+
+```js
+["nav", "aside", "footer", "form", "[aria-hidden='true']", "[hidden]"]
+```
+
+It is **not** applied by default — opt-in only, so upgrading to this
+release won't change existing markdown output unless you ask for it.
 
 ## Output Files
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-llms-md",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Generate llms.txt, llms-full.txt, and individual markdown files from your Astro site with this Astro integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,32 @@ export interface LlmsIntegrationOptions {
   titleSelector?: string;
   contentSelector?: string;
   exclude?: string[];
+  /**
+   * CSS selectors to remove from each page's content BEFORE the
+   * HTML → Markdown conversion. Useful for stripping sidebars,
+   * navigation, forms, or any element that adds noise to the
+   * generated markdown output.
+   *
+   * `script`, `style`, and `[data-llms-ignore]` are always stripped
+   * regardless of this option — `[data-llms-ignore]` is an opt-in
+   * attribute escape hatch so template authors can mark individual
+   * elements without touching the integration config.
+   *
+   * Defaults to `[]` (only the always-stripped trio applies). To
+   * filter common noise patterns, spread the exported constant:
+   *
+   * ```js
+   * import llms, { DEFAULT_NOISE_SELECTORS } from "astro-llms-md";
+   *
+   * llms({
+   *   excludeSelectors: [
+   *     ...DEFAULT_NOISE_SELECTORS,
+   *     ".my-custom-class",
+   *   ],
+   * });
+   * ```
+   */
+  excludeSelectors?: string[];
   verbose?: boolean;
 }
 
@@ -30,6 +56,7 @@ export interface LlmsConfig {
   titleSelector?: string;
   contentSelector?: string;
   exclude?: string[];
+  excludeSelectors?: string[];
   verbose?: boolean;
 }
 
@@ -50,6 +77,7 @@ interface FormatterConfig {
 interface ProcessOptions {
   titleSelector: string;
   contentSelector: string;
+  excludeSelectors: string[];
 }
 
 interface ResolvedIntegrationConfig {
@@ -62,8 +90,54 @@ interface ResolvedIntegrationConfig {
   titleSelector: string;
   contentSelector: string;
   exclude: string[];
+  excludeSelectors: string[];
   verbose: boolean;
 }
+
+/**
+ * Selectors that are always stripped from page content before HTML→MD
+ * conversion. `script` and `style` are JS/CSS — never useful in
+ * Markdown. `[data-llms-ignore]` is an opt-in attribute escape hatch
+ * so template authors can mark individual elements as "skip me" without
+ * needing to coordinate with the integration config.
+ *
+ * Not user-configurable. To strip more elements, pass `excludeSelectors`
+ * (additive — combined with this list at process time).
+ */
+export const BUILT_IN_EXCLUDE_SELECTORS: readonly string[] = [
+  "script",
+  "style",
+  "[data-llms-ignore]",
+];
+
+/**
+ * Opinionated list of common "noise" selectors that most sites want
+ * stripped from their AI-readable markdown — sidebars, navigation,
+ * forms, hidden content, etc. Exported as a convenience so users can
+ * opt in by spreading into their own `excludeSelectors`:
+ *
+ * ```js
+ * import llms, { DEFAULT_NOISE_SELECTORS } from "astro-llms-md";
+ *
+ * llms({
+ *   excludeSelectors: [
+ *     ...DEFAULT_NOISE_SELECTORS,
+ *     ".my-custom-class",
+ *   ],
+ * });
+ * ```
+ *
+ * Not applied by default — opt-in only, so existing users see no
+ * behavior change.
+ */
+export const DEFAULT_NOISE_SELECTORS: readonly string[] = [
+  "nav",
+  "aside",
+  "footer",
+  "form",
+  "[aria-hidden='true']",
+  "[hidden]",
+];
 
 /**
  * Default configuration
@@ -78,6 +152,7 @@ const defaultConfig: ResolvedIntegrationConfig = {
   titleSelector: "h1",
   contentSelector: "main",
   exclude: ["404", "404.html", "_astro", "**.xml", "**.txt", "node_modules"],
+  excludeSelectors: [],
   verbose: false,
 };
 
@@ -128,7 +203,7 @@ async function processHtmlFile(
   filePath: string,
   options: ProcessOptions,
 ): Promise<Omit<PageData, "urlPath" | "filePath">> {
-  const { titleSelector, contentSelector } = options;
+  const { titleSelector, contentSelector, excludeSelectors } = options;
 
   const html = await readFile(filePath, "utf8");
   const root = parse(html);
@@ -146,10 +221,16 @@ async function processHtmlFile(
   let content = "";
 
   if (contentElement) {
-    // Remove script and style tags
-    contentElement
-      .querySelectorAll("script, style")
-      .forEach((el) => el.remove());
+    // Strip noise elements before conversion. BUILT_IN_EXCLUDE_SELECTORS
+    // is always applied (script/style/[data-llms-ignore]); user-supplied
+    // selectors extend it. De-duped so explicit overlaps don't cost a
+    // second pass.
+    const selectors = Array.from(
+      new Set([...BUILT_IN_EXCLUDE_SELECTORS, ...excludeSelectors]),
+    ).join(", ");
+    if (selectors) {
+      contentElement.querySelectorAll(selectors).forEach((el) => el.remove());
+    }
 
     // Convert HTML to markdown
     const turndownService = new TurndownService({
@@ -289,6 +370,7 @@ export async function generateLlmsFiles(config: LlmsConfig): Promise<void> {
     titleSelector = "h1",
     contentSelector = "main",
     exclude = defaultConfig.exclude,
+    excludeSelectors = defaultConfig.excludeSelectors,
     verbose = false,
   } = config;
 
@@ -320,6 +402,7 @@ export async function generateLlmsFiles(config: LlmsConfig): Promise<void> {
       const pageData = await processHtmlFile(file, {
         titleSelector,
         contentSelector,
+        excludeSelectors,
       });
 
       if (!pageData.title) {
@@ -493,6 +576,7 @@ export default function llmsIntegration(options: LlmsIntegrationOptions = {}) {
             titleSelector: mergedOptions.titleSelector,
             contentSelector: mergedOptions.contentSelector,
             exclude: mergedOptions.exclude,
+            excludeSelectors: mergedOptions.excludeSelectors,
             verbose: mergedOptions.verbose,
           };
 


### PR DESCRIPTION
## Summary

Adds an `excludeSelectors` option that lets users strip arbitrary CSS-selectable elements from the parsed content **before** the HTML → Markdown conversion. Useful for any element that exists for human readers but is pure noise when an LLM is the audience.

## API additions

**New option** on `LlmsIntegrationOptions`:
```ts
excludeSelectors?: string[];  // additive, default []
```

**Two exported constants** for ergonomics:
```ts
export const BUILT_IN_EXCLUDE_SELECTORS: readonly string[];
// ["script", "style", "[data-llms-ignore]"]
// — always applied, not user-overridable

export const DEFAULT_NOISE_SELECTORS: readonly string[];
// ["nav", "aside", "footer", "form", "[aria-hidden='true']", "[hidden]"]
// — opinionated common-noise preset; opt-in via spread
```

## Behavior

- `script` and `style` are still stripped automatically (preserves prior behavior — they're now in `BUILT_IN_EXCLUDE_SELECTORS`).
- New `[data-llms-ignore]` attribute is always honored — a lightweight markup-side escape hatch so template authors can mark elements as "skip me" without touching the integration config:
  ```astro
  <aside data-llms-ignore>...</aside>
  ```
- Anything else is opt-in — users pass `excludeSelectors`, or spread `DEFAULT_NOISE_SELECTORS` for the common preset:
  ```js
  import llms, { DEFAULT_NOISE_SELECTORS } from "astro-llms-md";

  llms({
    excludeSelectors: [
      ...DEFAULT_NOISE_SELECTORS,
      ".my-custom-class",
    ],
  });
  ```

## Backwards compatibility

Fully additive. Default `excludeSelectors: []` means existing users see zero change in generated markdown — only `script`/`style` continue to be stripped as before. Version bumped to **2.1.0**.

## Motivation

The integration converts everything inside `contentSelector` (default `main`) into markdown. On real-world content sites that often includes elements that are perfectly valid inside the main content for human visitors but actively hurt the AI-readable output:

- inline newsletter sign-ups / "Get a quote" forms that render as `First name * Last name * Email * Subscribe`
- inline CTA cards that render as detached link lists
- related-posts grids that double the page word count with link soup
- breadcrumbs, comment widgets, share-buttons rendered inline with article copy

These aren't necessarily in `<aside>` or outside the main column — they can sit anywhere in the content tree (a CTA mid-article, a sign-up under the hero, etc.), so the existing `contentSelector` API can't cleanly exclude them without restructuring the markup.

For LLM-readable output and SEO/AI-discovery use cases (which is the whole point of `llms.txt` / per-page `.md`), authors need a way to say "this DOM subtree is for humans only". CSS selectors are the natural way to express that, and a `[data-llms-ignore]` attribute covers the ad-hoc per-element case without touching config.

## Test plan

- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Build emits expected exports in `dist/index.{js,d.ts}`
- [x] Smoke test on synthetic HTML confirms `aside`/`form`/`[data-llms-ignore]` are stripped while main content is preserved
- [x] End-to-end test on a real Astro site with ~2,000 generated pages: CTA-form text gone from the `.md` siblings, no regression on pages without any matching elements
- [x] Backwards-compatible: default config produces identical output to 2.0.0

## Files changed

- `src/index.ts` — option, constants, `processHtmlFile` threading
- `README.md` — new "Excluding noise from generated markdown" section + table entry
- `package.json` — version 2.0.0 → 2.1.0