### PR TITLE
feat: add trailingSlash option, inherit from Astro config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # astro-llms-md
 
-[![npm version](https://badge.fury.io/js/astro-llms-md.svg)](https://www.npmjs.com/package/astro-llms-md)
+[![npm version](https://img.shields.io/npm/v/astro-llms-md.svg)](https://www.npmjs.com/package/astro-llms-md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Listed on Astro Integrations: [astro-llms-md on astro.build](https://astro.build/integrations/?search=astro-llms-md)
@@ -75,6 +75,7 @@ export default defineConfig({
       contentSelector: "main",
       exclude: ["404", "404.html", "_astro"],
       excludeSelectors: ["aside", "form", "[data-llms-ignore]"],
+      trailingSlash: "always",
       verbose: false,
     }),
   ],
@@ -97,6 +98,7 @@ All configuration is defined in `astro.config.mjs` via `llms({...})`. The integr
 | `contentSelector`      | string  | `"main"`      | CSS selector for main content  |
 | `exclude`              | array   | see below     | File path patterns to exclude  |
 | `excludeSelectors`     | array   | `[]`          | CSS selectors to strip from content before HTML → MD conversion (see below) |
+| `trailingSlash`        | string  | inherits from Astro | `"always"`, `"never"`, or `"ignore"` — controls trailing slash on emitted page URLs (see below) |
 | `verbose`              | boolean | `false`       | Detailed output                |
 
 ### Default Excludes
@@ -166,6 +168,43 @@ llms({
 
 It is **not** applied by default — opt-in only, so upgrading to this
 release won't change existing markdown output unless you ask for it.
+
+### Trailing slash on emitted URLs
+
+`trailingSlash` controls whether canonical page URLs end with `/`. Accepts
+the same three values as Astro's [top-level `trailingSlash`](https://docs.astro.build/en/reference/configuration-reference/#trailingslash):
+
+| Value      | Behavior                                                            |
+| ---------- | ------------------------------------------------------------------- |
+| `"always"` | Append `/` to every emitted page URL                                |
+| `"never"`  | Strip trailing `/` from every emitted page URL                      |
+| `"ignore"` | Derive from `build.format` — `directory` → `"always"`, `file` → `"never"` |
+
+`"ignore"` follows Astro's [recommended pairings](https://docs.astro.build/en/reference/configuration-reference/#buildformat)
+(`directory + always`, `file + never`) so the emitted canonical lines up with
+the actual URL Astro serves for that build format.
+
+When not set, the integration inherits the value from your `astro.config`,
+including `build.format`. So a project on Astro defaults (`trailingSlash: "ignore"`
++ `build.format: "directory"`) gets canonicals ending in `/` automatically —
+matching what Astro serves on disk:
+
+```js
+// astro.config.mjs — Astro defaults
+export default defineConfig({
+  integrations: [llms()],  // emits https://site.com/about/
+});
+```
+
+To override explicitly, pass `trailingSlash` to `llms()`:
+
+```js
+llms({ trailingSlash: "never" });
+```
+
+This only affects page URLs (the `url:` field in individual `.md` files
+and the `URL:` line in `llms-full.txt`). The `.md` file links inside
+`llms.txt` are file URLs and never carry a trailing slash regardless.
 
 ## Output Files
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-llms-md",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Generate llms.txt, llms-full.txt, and individual markdown files from your Astro site with this Astro integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,10 @@ import { dirname, join, resolve } from "path";
 import TurndownService from "turndown";
 import { fileURLToPath } from "url";
 
+export type TrailingSlashMode = "always" | "never" | "ignore";
+
+type BuildFormat = "directory" | "file" | "preserve";
+
 export interface LlmsIntegrationOptions {
   siteUrl?: string;
   name?: string;
@@ -16,6 +20,7 @@ export interface LlmsIntegrationOptions {
   contentSelector?: string;
   exclude?: string[];
   excludeSelectors?: string[];
+  trailingSlash?: TrailingSlashMode;
   verbose?: boolean;
 }
 
@@ -32,6 +37,8 @@ export interface LlmsConfig {
   contentSelector?: string;
   exclude?: string[];
   excludeSelectors?: string[];
+  trailingSlash?: TrailingSlashMode;
+  buildFormat?: BuildFormat;
   verbose?: boolean;
 }
 
@@ -47,6 +54,8 @@ interface FormatterConfig {
   name: string;
   description: string;
   siteUrl: string;
+  trailingSlash: TrailingSlashMode;
+  buildFormat: BuildFormat;
 }
 
 interface ProcessOptions {
@@ -66,6 +75,8 @@ interface ResolvedIntegrationConfig {
   contentSelector: string;
   exclude: string[];
   excludeSelectors: string[];
+  trailingSlash: TrailingSlashMode;
+  buildFormat: BuildFormat;
   verbose: boolean;
 }
 
@@ -98,8 +109,30 @@ const defaultConfig: ResolvedIntegrationConfig = {
   contentSelector: "main",
   exclude: ["404", "404.html", "_astro", "**.xml", "**.txt", "node_modules"],
   excludeSelectors: [],
+  trailingSlash: "ignore",
+  buildFormat: "directory",
   verbose: false,
 };
+
+function resolveTrailingSlash(
+  mode: TrailingSlashMode,
+  buildFormat: BuildFormat,
+): "always" | "never" {
+  if (mode === "always" || mode === "never") return mode;
+  return buildFormat === "file" ? "never" : "always";
+}
+
+function applyTrailingSlash(
+  url: string,
+  mode: TrailingSlashMode,
+  buildFormat: BuildFormat,
+): string {
+  const resolved = resolveTrailingSlash(mode, buildFormat);
+  if (resolved === "always") {
+    return url.endsWith("/") ? url : `${url}/`;
+  }
+  return url.replace(/\/+$/, "");
+}
 
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) {
@@ -197,8 +230,12 @@ async function processHtmlFile(
  * Generate markdown file content for a page
  */
 function generateMarkdownFile(page: PageData, config: FormatterConfig): string {
-  const { siteUrl } = config;
-  const url = `${siteUrl}${page.urlPath}`.replace(/\/$/, "");
+  const { siteUrl, trailingSlash, buildFormat } = config;
+  const url = applyTrailingSlash(
+    `${siteUrl}${page.urlPath}`,
+    trailingSlash,
+    buildFormat,
+  );
 
   let md = "---\n";
   md += `title: "${page.title}"\n`;
@@ -275,13 +312,17 @@ function generateLlmsFullTxtContent(
   pages: PageData[],
   config: FormatterConfig,
 ): string {
-  const { name, siteUrl } = config;
+  const { name, siteUrl, trailingSlash, buildFormat } = config;
 
   let content = `# ${name}\n\n`;
-  content += `URL: ${siteUrl}\n\n`;
+  content += `URL: ${applyTrailingSlash(siteUrl, trailingSlash, buildFormat)}\n\n`;
 
   pages.forEach((page, index) => {
-    const url = `${siteUrl}${page.urlPath}`.replace(/\/$/, "");
+    const url = applyTrailingSlash(
+      `${siteUrl}${page.urlPath}`,
+      trailingSlash,
+      buildFormat,
+    );
     content += `## ${page.title}\n\n`;
     content += `URL: ${url}\n\n`;
 
@@ -316,6 +357,8 @@ export async function generateLlmsFiles(config: LlmsConfig): Promise<void> {
     contentSelector = "main",
     exclude = defaultConfig.exclude,
     excludeSelectors = defaultConfig.excludeSelectors,
+    trailingSlash = defaultConfig.trailingSlash,
+    buildFormat = defaultConfig.buildFormat,
     verbose = false,
   } = config;
 
@@ -384,6 +427,8 @@ export async function generateLlmsFiles(config: LlmsConfig): Promise<void> {
     name: siteName,
     description: siteDescription,
     siteUrl: siteUrl.replace(/\/$/, ""),
+    trailingSlash,
+    buildFormat,
   };
 
   // Generate individual .md files
@@ -473,6 +518,8 @@ export async function generateLlmsFiles(config: LlmsConfig): Promise<void> {
  */
 export default function llmsIntegration(options: LlmsIntegrationOptions = {}) {
   let astroSiteUrl = "";
+  let astroTrailingSlash: TrailingSlashMode | undefined;
+  let astroBuildFormat: BuildFormat | undefined;
 
   return {
     name: "astro-llms-md",
@@ -481,12 +528,18 @@ export default function llmsIntegration(options: LlmsIntegrationOptions = {}) {
         config,
         logger,
       }: {
-        config: { site?: URL | string };
+        config: {
+          site?: URL | string;
+          trailingSlash?: TrailingSlashMode;
+          build?: { format?: BuildFormat };
+        };
         logger: { info: (message: string) => void };
       }) => {
         logger.info("Setting up astro-llms-md integration...");
 
         astroSiteUrl = config.site?.toString?.() || "";
+        astroTrailingSlash = config.trailingSlash;
+        astroBuildFormat = config.build?.format;
       },
 
       "astro:build:done": async ({
@@ -506,6 +559,8 @@ export default function llmsIntegration(options: LlmsIntegrationOptions = {}) {
           const distDir = fileURLToPath(dir);
           const mergedOptions: ResolvedIntegrationConfig = {
             ...defaultConfig,
+            trailingSlash: astroTrailingSlash ?? defaultConfig.trailingSlash,
+            buildFormat: astroBuildFormat ?? defaultConfig.buildFormat,
             ...options,
           };
 
@@ -522,6 +577,8 @@ export default function llmsIntegration(options: LlmsIntegrationOptions = {}) {
             contentSelector: mergedOptions.contentSelector,
             exclude: mergedOptions.exclude,
             excludeSelectors: mergedOptions.excludeSelectors,
+            trailingSlash: mergedOptions.trailingSlash,
+            buildFormat: mergedOptions.buildFormat,
             verbose: mergedOptions.verbose,
           };
 


### PR DESCRIPTION
## Summary

Adds a `trailingSlash` option that controls canonical page URLs emitted in the generated `.md` frontmatter and `llms-full.txt`. Mirrors Astro's own [`trailingSlash`](https://docs.astro.build/en/reference/configuration-reference/#trailingslash) vocabulary 1:1 (`"always" | "never" | "ignore"`) and inherits from `astro.config` by default — zero extra config needed.

## API additions

```ts
trailingSlash?: "always" | "never" | "ignore";
```

Exported type:
```ts
export type TrailingSlashMode = "always" | "never" | "ignore";
```

## Behavior

| Value      | Effect on emitted page URLs                                       |
| ---------- | ----------------------------------------------------------------- |
| `"always"` | Append `/` (e.g. `https://site.com/about/`)                       |
| `"never"`  | Strip trailing `/` (e.g. `https://site.com/about`)                |
| `"ignore"` | Derive from `build.format` per Astro's recommended pairings: `directory` → `"always"`, `file` → `"never"` |

**Resolution order**: explicit `llms({ trailingSlash })` → Astro `config.trailingSlash` → `"ignore"`.

`build.format` is also captured from `astro.config` so `"ignore"` resolution matches what Astro actually serves on disk.

**Scope**: only canonical page URLs — `url:` in individual `.md` files and `URL:` lines in `llms-full.txt`. The `.md` file links inside `llms.txt` are file URLs and never get a trailing slash.

## Motivation

Astro projects on the default config (`trailingSlash: "ignore"` + `build.format: "directory"`) serve pages at `/about/` — but the integration was emitting `url: "https://site.com/about"` in the generated `.md` frontmatter, a silent canonical mismatch for the majority of users.

The fix follows Astro's own [recommended pairings](https://docs.astro.build/en/reference/configuration-reference/#buildformat): `directory + always`, `file + never`. By inheriting both `trailingSlash` and `build.format`, the integration now emits canonicals that match what Astro serves — no user action required.

Users with explicit `trailingSlash: "always"` or `"never"` in `astro.config` get matching canonicals automatically too.

## Backwards compatibility

Output changes for users on Astro defaults (`ignore + directory`) — canonicals gain a trailing slash. Users with explicit `trailingSlash: "never"` see no change. Users with explicit `trailingSlash: "always"` get the correct canonical (was a bug before).

Version bumped to **2.2.0**.

Drive-by: replaced the `badge.fury.io` npm version badge with `img.shields.io/npm/v` — same package, but shields reads npm registry directly so it doesn't lag behind real releases.

## Test plan

- [x] TypeScript compiles cleanly (`npm run typecheck`)
- [x] Build emits expected exports in `dist/index.{js,d.ts}`
- [x] Smoke test matrix: 3 modes × 2 build formats × fixture site (root + 2 subpages) — `url:` and `URL:` lines emit correctly in all 6 combinations
- [x] `.md` file links in `llms.txt` unaffected by mode

## Files changed

- `src/index.ts` — new `TrailingSlashMode` type, `applyTrailingSlash`/`resolveTrailingSlash` helpers, threading through `astro:config:setup`
- `README.md` — new "Trailing slash on emitted URLs" section + table entry + npm badge swap
- `package.json` — version 2.1.0 → 2.2.0