### PR TITLE
chore: add issue/PR templates and auto-assign workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,133 @@
+name: Bug report
+description: File a bug report to help us improve astro-llms-md.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report! Please fill out the
+        sections below so we can reproduce and fix the issue quickly.
+
+        Before submitting:
+        - Make sure you're on the latest version of `astro-llms-md`.
+        - Search [existing issues](https://github.com/tfmurad/astro-llms-md/issues?q=is%3Aissue) to avoid duplicates.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear and concise description of what the bug is.
+      placeholder: When I run `astro build` with X enabled, the generated `llms.txt` does Y instead of Z.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimum steps someone else can follow to see the same behavior.
+      placeholder: |
+        1. Run `npm create astro@latest -- --template starlight`
+        2. Add `astro-llms-md` to integrations with `llms({ ... })`
+        3. Run `astro build`
+        4. Open `dist/llms.txt`
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include error messages and stack traces if any.
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: integration-version
+    attributes:
+      label: astro-llms-md version
+      placeholder: e.g. 2.1.0
+    validations:
+      required: true
+
+  - type: input
+    id: astro-version
+    attributes:
+      label: Astro version
+      placeholder: e.g. 5.0.0
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      placeholder: e.g. 20.11.0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: output-mode
+    attributes:
+      label: Astro `output` mode
+      options:
+        - "static (default)"
+        - "server (SSR)"
+        - "hybrid"
+        - "not sure"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: build-format
+    attributes:
+      label: Astro `build.format`
+      options:
+        - "directory (default)"
+        - "file"
+        - "preserve"
+        - "not sure"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: how-reproduced
+    attributes:
+      label: How are you running / hitting the integration?
+      description: This matters — the integration only runs at build time, not in `astro dev`.
+      options:
+        - "astro dev (dev server)"
+        - "astro preview after astro build"
+        - "Deployed site (Cloudflare / Netlify / Vercel / other)"
+        - "Other / multiple"
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: Relevant integration config
+      description: Paste the `llms({ ... })` call from your `astro.config.mjs`.
+      render: javascript
+      placeholder: |
+        llms({
+          generateLlmsTxt: true,
+          excludeSelectors: ["aside", "form"],
+          // ...
+        })
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else?
+      description: Screenshots, deployment platform, related issues, etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contribution guide
+    url: https://github.com/tfmurad/astro-llms-md/blob/main/CONTRIBUTING.md
+    about: How to set up the project locally, submit PRs, and follow the commit conventions.
+  - name: Astro Discord
+    url: https://astro.build/chat
+    about: For general Astro questions that aren't specific to this integration.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: Suggest a new option, behavior, or improvement.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an idea! Before submitting, please:
+        - Search [existing issues](https://github.com/tfmurad/astro-llms-md/issues?q=is%3Aissue) to avoid duplicates.
+        - Skim the [README](https://github.com/tfmurad/astro-llms-md#readme) — the feature might already exist.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case you're trying to address. Real-world context helps a lot.
+      placeholder: I'm building a docs site where the sidebar emits a sign-up form on every page, and it ends up in the generated `.md` siblings as noise.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would the API or behavior look like? Pseudo-code is welcome.
+      placeholder: |
+        A new option `excludeSelectors: string[]` that gets stripped from the HTML before MD conversion.
+        ```js
+        llms({ excludeSelectors: ["aside", "form"] })
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds you've tried, or other approaches you weighed?
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Roughly, how big is this?
+      options:
+        - "Tiny — option/flag tweak"
+        - "Moderate — new option or behavior"
+        - "Large — new generator / output / architectural change"
+        - "Not sure"
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else?
+      description: Links to related issues, similar features in other tools, prior art, etc.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## Description
+
+<!-- What does this PR do? Why is it needed? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+- [ ] Chore / tooling
+
+## Testing
+
+<!-- How did you test these changes? Include the Astro versions / output modes you exercised. -->
+
+- [ ] `npm run typecheck` passes
+- [ ] `npm run build` produces expected `dist/index.{js,d.ts}`
+- [ ] Manually tested against a real Astro site
+- [ ] N/A — docs / tooling only
+
+## Checklist
+
+- [ ] My code follows the style of the existing codebase
+- [ ] I have self-reviewed my changes
+- [ ] I have updated `README.md` / `CONTRIBUTING.md` where relevant
+- [ ] I have bumped `package.json` version if this is a release-worthy change
+- [ ] Linked any related issues below
+
+## Related issues
+
+<!-- Closes #123, refs #456, etc. -->

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,39 @@
+name: Auto-assign PR
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign maintainer
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const maintainer = "tfmurad";
+
+            if (pr.user.login === maintainer) {
+              core.info(`PR opened by ${maintainer} — skipping self-assignment.`);
+              return;
+            }
+
+            const current = (pr.assignees || []).map((u) => u.login);
+            if (current.includes(maintainer)) {
+              core.info(`${maintainer} already assigned.`);
+              return;
+            }
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              assignees: [maintainer],
+            });
+            core.info(`Assigned ${maintainer} to PR #${pr.number}.`);


### PR DESCRIPTION
## Description

Adds GitHub Issue Forms for bug reports and feature requests, plus a matching PR template and an auto-assign workflow. Pure tooling — no source code changes.

## What's in the box

### Issue Forms (`.github/ISSUE_TEMPLATE/`)

- **`bug_report.yml`** — structured form that captures everything diagnosis usually needs: a summary, repro steps, expected vs actual behavior, `astro-llms-md` / Astro / Node versions, Astro `output` mode (static / server / hybrid), `build.format`, and crucially **how** the user is hitting the integration (`astro dev` vs `astro preview` vs deployed). That last field would have closed [#1](https://github.com/tfmurad/astro-llms-md/issues/1) in one round — the integration only runs on `astro build`, so dev-server hits 404.
- **`feature_request.yml`** — captures the underlying problem, proposed API, alternatives considered, and rough scope. Mirrors the structure asked for in `CONTRIBUTING.md > Suggesting Features`.
- **`config.yml`** — disables blank issues and routes general Astro questions to the Astro Discord; points contributors at `CONTRIBUTING.md`.

### PR template (`.github/PULL_REQUEST_TEMPLATE.md`)

Direct lift of the checklist already documented in `CONTRIBUTING.md > Pull Request Template`, with the addition of a Testing section (typecheck / build / manual test boxes) and a Related issues field.

### Auto-assign workflow (`.github/workflows/auto-assign.yml`)

Assigns new PRs to @tfmurad on `opened` / `reopened` / `ready_for_review`. Uses `actions/github-script@v9` (latest), no third-party dependencies. Skips self-PRs from @tfmurad and PRs where the maintainer is already assigned.

Runs on `pull_request_target` (not `pull_request`) — the workflow code that executes is the version on `main`, not from the contributor's fork, which is the safe pattern for actions that need write permissions on the PR.

## Why

Issue [#1](https://github.com/tfmurad/astro-llms-md/issues/1) had a ~3-week back-and-forth that boiled down to "are you on dev or build mode?". A structured bug form prevents that round-trip — the user can't open the issue without picking from `astro dev` / `astro preview` / deployed in the dropdown.

The PR template + auto-assign workflow keep PRs visible in your assigned queue without you having to babysit the notifications.

## Files added

- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/feature_request.yml`
- `.github/ISSUE_TEMPLATE/config.yml`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/workflows/auto-assign.yml`

## Test plan

- [x] YAML parses cleanly (verified with `ruby -ryaml`)
- [x] GitHub Issue Form schema fields used (`name` / `description` / `body` / `title` / `labels` / `body.type` of `markdown` / `textarea` / `input` / `dropdown`) match the [Issue Forms reference](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms)
- [x] `actions/github-script@v9` API surface compatible — the script uses standard `github.rest.issues.addAssignees` and `core.info`, none of the v9 breaking-change patterns (no `require('@actions/github')`, no redeclared `getOctokit`)
- [ ] Workflow will be exercised live on the next PR after this one merges

Independent of #3 — can land in either order.