### PR TITLE
fix: generate index.md for root path when using generateIndividualMd

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -438,10 +438,9 @@ export async function generateLlmsFiles(config: LlmsConfig): Promise<void> {
     }
 
     for (const page of pages) {
-      const mdPath = join(
-        resolvedOutputDir,
-        page.urlPath.replace(/^\//, "") + ".md",
-      );
+      const urlPathForFile =
+        page.urlPath === "/" ? "index" : page.urlPath.replace(/^\//, "");
+      const mdPath = join(resolvedOutputDir, urlPathForFile + ".md");
 
       const mdContent = generateMarkdownFile(page, formatterConfig);
 


### PR DESCRIPTION
## Description

When `generateIndividualMd: true` is set, the root page (`urlPath === "/"`) is written as `.md` instead of `index.md`.

Stripping the leading slash from `"/"` leaves an empty string, so `join(outputDir, "" + ".md")` produces a stray `.md` file:

```ts
// Before
page.urlPath.replace(/^\//, "") + ".md"
// "/" → "" → ".md"  ✗

// After
const urlPathForFile =
  page.urlPath === "/" ? "index" : page.urlPath.replace(/^\//, "");
// "/" → "index" → "index.md"  ✓
```

Discovered in production and patched locally via `pnpm patch` before submitting upstream.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

Tested manually by running `npm run typecheck` and `npm run build` against the patched source — both pass cleanly. The fix was also validated in a live production Astro site — https://www.historyofphuket.com/index.md now resolves correctly as a result of this fix.

## Checklist

- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed — no docs changes required for this fix)
- [x] No console errors