### PR TITLE
chore: add Astro 7 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-llms-md",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Generate llms.txt, llms-full.txt, and individual markdown files from your Astro site with this Astro integration",
   "type": "module",
   "main": "./dist/index.js",
@@ -47,7 +47,7 @@
     "url": "https://github.com/tfmurad/astro-llms-md/issues"
   },
   "peerDependencies": {
-    "astro": "^4.0.0 || ^5.0.0 || ^6.0.0"
+    "astro": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "dependencies": {
     "glob": "^13.0.6",


### PR DESCRIPTION
## Description

Expands peerDependencies to allow Astro 7, resolving npm ERESOLVE errors when installing with astro@^7.0.0.

## Type of Change

- [x] Maintenance / compatibility update

## Testing

- npm run typecheck passes
- npm run build passes

## Checklist

- [x] Version bumped to 2.2.2
- [x] Peer dependency range updated
- [x] Build passes
