### PR TITLE
fix: flatten block-level content inside links to valid inline links

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -273,6 +273,49 @@ function addTableRule(turndownService: TurndownService): void {
   });
 }
 
+const BLOCK_LEVEL_ELEMENTS = [
+  "ADDRESS", "ARTICLE", "ASIDE", "BLOCKQUOTE", "DD", "DIV", "DL", "DT",
+  "FIELDSET", "FIGCAPTION", "FIGURE", "FORM", "H1", "H2", "H3", "H4", "H5",
+  "H6", "HEADER", "HGROUP", "LI", "OL", "P", "PRE", "SECTION", "TABLE", "UL",
+];
+
+// Collects visible text, inserting a space at block boundaries so
+// "<h3>Hi</h3><p>d</p>" becomes "Hi d" rather than "Hid".
+function flattenText(node: ChildNode): string {
+  if (node.nodeType === 3) return node.textContent || "";
+  const inner = Array.from(node.childNodes).map(flattenText).join("");
+  return BLOCK_LEVEL_ELEMENTS.includes(node.nodeName) ? ` ${inner} ` : inner;
+}
+
+// A valid-in-HTML <a> can wrap block elements (a heading card, a whole
+// section). Block rules inside it inject newlines into the link text, which
+// most markdown renderers then refuse to parse as a link at all. Emit a
+// single inline link with flattened plain text instead.
+// Mirrors turndown's own inline-link escaping for href/title.
+function addBlockInLinkRule(turndownService: TurndownService): void {
+  turndownService.addRule("linkWithBlocks", {
+    filter: (node) =>
+      node.nodeName === "A" &&
+      !!node.getAttribute("href") &&
+      Array.from(node.querySelectorAll("*")).some((el) =>
+        BLOCK_LEVEL_ELEMENTS.includes(el.nodeName),
+      ),
+    replacement: (_content, node) => {
+      const text = flattenText(node)
+        .replace(/\s+/g, " ")
+        .trim()
+        .replace(/([\\[\]])/g, "\\$1");
+      if (!text) return "";
+      let href = (node.getAttribute("href") || "").replace(/([<>()])/g, "\\$1");
+      if (href.includes(" ")) href = `<${href}>`;
+      const title = (node.getAttribute("title") || "")
+        .replace(/(\n+\s*)+/g, "\n")
+        .replace(/"/g, '\\"');
+      return `[${text}](${href}${title ? ` "${title}"` : ""})`;
+    },
+  });
+}
+
 export async function processHtml(
   html: string,
   llmsConfig?: LlmsInternalConfig,
@@ -298,6 +341,7 @@ export async function processHtml(
       bulletListMarker: "-",
     });
     addTableRule(turndownService);
+    addBlockInLinkRule(turndownService);
 
     turndownService.addRule("removeChrome", {
       filter: ["nav", "footer", "header", "aside"],

--- a/tests/link-with-blocks.test.mjs
+++ b/tests/link-with-blocks.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { processHtml } from "../dist/index.js";
+
+function wrap(html) {
+  return `<html><body><main>${html}</main></body></html>`;
+}
+
+test("heading inside a link flattens to an inline link", async () => {
+  const { content } = await processHtml(
+    wrap('<a href="/tools/one"><h2>Tool One</h2></a>'),
+  );
+  assert.equal(content.trim(), "[Tool One](/tools/one)");
+});
+
+test("link with blocks with heading and description flattens to one line", async () => {
+  const { content } = await processHtml(
+    wrap('<a href="/x"><h3>Card Title</h3><p>Some description</p></a>'),
+  );
+  assert.equal(content.trim(), "[Card Title Some description](/x)");
+});
+
+test("nested blocks inside a link flatten", async () => {
+  const { content } = await processHtml(
+    wrap('<a href="/x"><div><h3>Hi</h3><p>d</p></div></a>'),
+  );
+  assert.equal(content.trim(), "[Hi d](/x)");
+});
+
+test("text around blocks inside a link is preserved with spaces", async () => {
+  const { content } = await processHtml(
+    wrap('<a href="/x">intro <h2>Head</h2> tail</a>'),
+  );
+  assert.equal(content.trim(), "[intro Head tail](/x)");
+});
+
+test("list inside a link flattens", async () => {
+  const { content } = await processHtml(
+    wrap('<a href="/x"><ul><li>one</li><li>two</li></ul></a>'),
+  );
+  assert.equal(content.trim(), "[one two](/x)");
+});
+
+test("link with blocks keeps sibling content as separate blocks", async () => {
+  const { content } = await processHtml(
+    wrap('<p>Before</p><a href="/x"><h2>Card</h2></a><p>After</p>'),
+  );
+  assert.equal(content.trim(), "Before\n\n[Card](/x)\n\nAfter");
+});
+
+test("link with blocks inside a list item", async () => {
+  const { content } = await processHtml(
+    wrap('<ul><li><a href="/x"><h4>Item</h4></a></li></ul>'),
+  );
+  assert.equal(content.trim(), "-   [Item](/x)");
+});
+
+test("markdown syntax in card text is stripped, not emitted", async () => {
+  const { content } = await processHtml(
+    wrap('<a href="/x"><h2>Card <em>styled</em> [bracket]</h2></a>'),
+  );
+  assert.equal(content.trim(), "[Card styled \\[bracket\\]](/x)");
+});
+
+test("link with blocks with title attribute keeps title", async () => {
+  const { content } = await processHtml(
+    wrap('<a href="/x" title="My Title"><h2>T</h2></a>'),
+  );
+  assert.equal(content.trim(), '[T](/x "My Title")');
+});
+
+test("plain inline links are untouched", async () => {
+  const { content } = await processHtml(
+    wrap('<p>See <a href="/about">the <strong>about</strong> page</a> now.</p>'),
+  );
+  assert.equal(content.trim(), "See [the **about** page](/about) now.");
+});
+
+test("image link is untouched", async () => {
+  const { content } = await processHtml(
+    wrap('<a href="/x"><img src="/i.png" alt="pic"></a>'),
+  );
+  assert.equal(content.trim(), "[![pic](/i.png)](/x)");
+});
+
+test("link without href stays plain", async () => {
+  const { content } = await processHtml(wrap("<a>no href</a>"));
+  assert.equal(content.trim(), "no href");
+});


### PR DESCRIPTION
Hey @tfmurad, found this edge case while using the plugin on my site, https://freshjuice.dev/tools/

My tool cards are links wrapping a heading + description (`<a href="..."><h3>Title</h3><p>desc</p></a>`), which is valid HTML. The generated markdown came out broken because turndown's heading/paragraph rules inject `\n\n` inside the link text:

```
[

## Tool One

](/tools/one)
```

Most markdown renderers refuse to parse that as a link, so the URL is lost entirely (visible via `curl -H "Accept: text/markdown" https://freshjuice.dev/tools/` on the page).

**Fix:** one extra turndown rule, when an `<a href>` contains block-level descendants, emit a single inline link with the inner content flattened to plain text instead: `[Tool One](/tools/one)`. Inline links and image links are untouched (the rule only fires on block-level children), and href/title escaping mirrors turndown's own inline-link rule.

Added 12 tests (`tests/link-with-blocks.test.mjs`); all 16 pass, `tsc --noEmit` clean.
