### PR TITLE
Restore excludeSelectors and the always-stripped [data-llms-ignore]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ export interface LlmsInternalConfig {
   title_selector?: string;
   content_selector?: string;
   exclude?: string[];
+  exclude_selectors?: string[];
   include?: string[];
 }
 
@@ -47,6 +48,7 @@ export interface LlmsIntegrationOptions {
   titleSelector?: string;
   contentSelector?: string;
   exclude?: string[];
+  excludeSelectors?: string[];
   include?: string[];
   verbose?: boolean;
 }
@@ -78,6 +80,16 @@ const DEFAULT_EXCLUDES = [
   "404.html",
   "**/*.xml",
   "**/*.txt",
+];
+
+// ─── Elements stripped from the content before conversion, always ──────────
+const ALWAYS_EXCLUDED_SELECTORS = [
+  "script",
+  "style",
+  "noscript",
+  "iframe",
+  "svg",
+  "[data-llms-ignore]",
 ];
 
 // ─── URL path prefixes that are API / system routes ──────────────────────────
@@ -288,8 +300,12 @@ export async function processHtml(
   let content = "";
 
   if (contentElement) {
+    const selectors = [
+      ...ALWAYS_EXCLUDED_SELECTORS,
+      ...(llmsConfig?.exclude_selectors || []),
+    ];
     contentElement
-      .querySelectorAll("script, style, noscript, iframe, svg")
+      .querySelectorAll(selectors.join(", "))
       .forEach((el) => el.remove());
 
     const turndownService = new TurndownService({
@@ -890,6 +906,8 @@ function mapOptionsToConfig(
       title_selector: options.titleSelector ?? projectLlms.title_selector,
       content_selector: options.contentSelector ?? projectLlms.content_selector,
       exclude: options.exclude ?? projectLlms.exclude ?? [],
+      exclude_selectors:
+        options.excludeSelectors ?? projectLlms.exclude_selectors ?? [],
       include: options.include ?? projectLlms.include ?? [],
     },
   };

--- a/tests/exclude_selectors.test.mjs
+++ b/tests/exclude_selectors.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { processHtml } from "../dist/index.js";
+
+function wrap(inner) {
+  return `<html><body><main>${inner}</main></body></html>`;
+}
+
+test("[data-llms-ignore] is always stripped", async () => {
+  const html = wrap(
+    "<p>Keep this.</p><section data-llms-ignore><p>Drop this.</p></section>",
+  );
+  const { content } = await processHtml(html);
+  assert.equal(content.trim(), "Keep this.");
+});
+
+test("excludeSelectors strips matching elements before conversion", async () => {
+  const html = wrap(
+    '<p>Keep this.</p><div class="promo"><p>Drop this.</p></div><form><input></form>',
+  );
+  const { content } = await processHtml(html, {
+    exclude_selectors: [".promo", "form"],
+  });
+  assert.equal(content.trim(), "Keep this.");
+});
+
+test("nothing extra is stripped without excludeSelectors", async () => {
+  const html = wrap('<p>Keep this.</p><div class="promo"><p>And this.</p></div>');
+  const { content } = await processHtml(html);
+  assert.equal(content.trim(), "Keep this.\n\nAnd this.");
+});


### PR DESCRIPTION
Hey! One more follow-up on #8.

The README still documents `excludeSelectors` and says `[data-llms-ignore]` is always stripped, but 3.0 lost both: the option is no longer on `LlmsIntegrationOptions`, and `processHtml` only removes `script`, `style`, `noscript`, `iframe` and `svg`. Anything a site had marked `data-llms-ignore` (a "contact support" card, a demo, a sign-up form) is back in the twins.

What changes:

- `excludeSelectors` is back on the options and mapped to `exclude_selectors` in the internal config, matching the other options.
- `[data-llms-ignore]` joins the always-stripped list.
- Nothing else about the conversion changes.

Checks:

- `npm run typecheck`
- `npm test`, with a new `tests/exclude_selectors.test.mjs`
- Our 62-page Astro 7 build drops the ignored blocks again.

Thanks!
